### PR TITLE
Make the can0 interface auto-restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ To run the automated installation script, copy-paste the following command onto 
 
 The command will fetch the installation script and execute it automatically.
 
-Manual installation is also possible. If you prefer to do that, follow the steps taken in `install.sh` and `configs/install_configs.sh`.
+Manual installation is also possible. If you prefer to do that, follow the [Software installation instructions](https://hatlabs.github.io/sh-rpi/pages/software/) on the documentation website.
+
 
 ## SH-RPi documentation
 

--- a/configs/can0.interface
+++ b/configs/can0.interface
@@ -1,4 +1,5 @@
 auto can0
 iface can0 can static
         bitrate 250000
+        pre-up ip link set can0 type can restart-ms 100
         up /sbin/ifconfig can0 txqueuelen 100


### PR DESCRIPTION
Found instructions at [SocketCAN documentation ](https://www.kernel.org/doc/html/latest/networking/can.html#starting-and-stopping-the-can-network-device) for auto-restarting the CAN interface instead of entering the bus-off error state. Applied the setting in the CAN interface definition file.