### PR TITLE
MCP2515 expects interrupts to be low level instead of falling edge

### DIFF
--- a/configs/mcp2515-can2-overlay.dts
+++ b/configs/mcp2515-can2-overlay.dts
@@ -63,7 +63,7 @@
                 pinctrl-0 = <&can2_pins>;
                 spi-max-frequency = <10000000>;
                 interrupt-parent = <&gpio>;
-                interrupts = <5 0x2>;
+                interrupts = <5 8>; /* IRQF_TRIGGER_LOW */
                 clocks = <&can2_osc>;
             };
         };


### PR DESCRIPTION
Only relevant for SH-RPi v1