### PR TITLE
Fix dialog defaults

### DIFF
--- a/configs/can0.interface
+++ b/configs/can0.interface
@@ -1,0 +1,5 @@
+auto can0
+iface can0 can static
+        bitrate 250000
+        pre-up ip link set can0 type can restart-ms 100
+        up /sbin/ifconfig can0 txqueuelen 100

--- a/configs/install_configs.sh
+++ b/configs/install_configs.sh
@@ -184,9 +184,9 @@ NOTE: Enabling the interface without the hardware present will significantly \
 degrade the Pi performance. \n\
 \n\
 Press SPACE to select, ENTER to accept selection and ESC to cancel." 20 75 3 \
-    "Enable" "Enable the CAN interface" ON \
+    "Enable" "Enable the CAN interface" off \
     "Disable" "Disable the CAN interface" off \
-    "Skip" "Do not change the CAN setting" off
+    "Skip" "Do not change the CAN setting" ON
 }
 
 do_dialog_rs485() {
@@ -198,9 +198,9 @@ This will allow the Pi to communicate with compatible devices such as \
 NMEA 0183 or Modbus RTU. \n\
 \n\
 Press SPACE to select, ENTER to accept selection and ESC to cancel." 20 75 3 \
-    "Enable" "Enable the RS485 interface" ON \
+    "Enable" "Enable the RS485 interface" off \
     "Disable" "Disable the RS485 interface" off \
-    "Skip" "Do not change the RS485 setting" off
+    "Skip" "Do not change the RS485 setting" ON
 }
 
 do_dialog() {


### PR DESCRIPTION
## Description

can0 interface file had accidentally been removed. Restored now.

Also, CAN and RS485 interfaces are not configured by default.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

