### PR TITLE
Fix installation on Pi OS Bookworm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,11 +22,25 @@ popd
 
 # install the daemon build dependencies
 
-apt install -y python3-pip
+apt install -y python3-pip python3-venv
+
+
+# If an existing venv is present, remove it
+if [ -d /usr/local/lib/shrpid ]; then
+    rm -rf /usr/local/lib/shrpid
+fi
+
+# Create a venv for the daemon
+python -m venv /usr/local/lib/shrpid
+source /usr/local/lib/shrpid/bin/activate
 
 # install the daemon itself
 
 pip3 install .
+
+# Create symlinks to the daemon and the CLI utility
+ln -sf /usr/local/lib/shrpid/bin/shrpid /usr/local/bin/shrpid
+ln -sf /usr/local/lib/shrpid/bin/shrpi /usr/local/bin/shrpi
 
 # copy the service definition file in place
 


### PR DESCRIPTION
## Description

Pi OS Bookworm had two changes that broke shrpid installation. First, Python no longer allows installing scripts and upstream packages in `/usr/local` without a separate override flag. Consequently, `shrpid` is installed in a private virtual environment in `/usr/local/lib/shrpid` and the scripts are symlinked to `/usr/local/bin`.

Second, the config file in `/boot/config.txt` has been moved to `/boot/firmware/config.txt`. A config file still exists in `/boot/config.txt` but is ignored...

## Related Issue

Fixes https://github.com/hatlabs/discussions/issues/76

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
