### PR TITLE
When creating a virtualenv for shrpid, call python3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ Steps to reproduce the behavior:
 * Python version, get it with:
 
 ```bash
-python --version
+python3 --version
 ```
 
 ### Screenshots

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ if [ -d /usr/local/lib/shrpid ]; then
 fi
 
 # Create a venv for the daemon
-python -m venv /usr/local/lib/shrpid
+python3 -m venv /usr/local/lib/shrpid
 source /usr/local/lib/shrpid/bin/activate
 
 # install the daemon itself


### PR DESCRIPTION
## Description

The venv for shrpid was created in install.sh by calling `python` which might have resulted in creation of a Python 2 venv on some older distros. Now, Python 3 is called explicitly.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
