### PR TITLE
Switch installer to use (global) uv instead of pipx

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ if [ -f /usr/local/bin/shrpi ]; then
 fi
 
 # install the daemon itself
-UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
+UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
 
 # copy the service definition file in place
 install -o root shrpid.service /lib/systemd/system

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,9 @@ pushd configs
 popd
 
 # install uv, which manages venv for installing the daemon
-curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+if ! [[ $(type -P "$cmd") ]]; then
+    curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+fi
 
 # If a legacy venv is present, remove it
 if [ -d /usr/local/lib/shrpid ]; then
@@ -37,11 +39,9 @@ if [ -f /usr/local/bin/shrpi ]; then
 fi
 
 # install the daemon itself
-
 UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
 
 # copy the service definition file in place
-
 install -o root shrpid.service /lib/systemd/system
 systemctl daemon-reload
 systemctl enable shrpid

--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,8 @@ pushd configs
 ./install_configs.sh "$@"
 popd
 
-# install the daemon build dependencies
-
-apt install -y python3-pip python3-venv pipx
+# install uv, which manages venv for installing the daemon
+curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 
 # If a legacy venv is present, remove it
 if [ -d /usr/local/lib/shrpid ]; then
@@ -37,13 +36,9 @@ if [ -f /usr/local/bin/shrpi ]; then
     rm /usr/local/bin/shrpi
 fi
 
-# Create a venv for the daemon
-python3 -m venv /usr/local/lib/shrpid
-source /usr/local/lib/shrpid/bin/activate
-
 # install the daemon itself
 
-PIPX_BIN_DIR=/usr/local/bin PIPX_HOME=/opt/pipx pipx install --force .
+UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
 
 # copy the service definition file in place
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,12 @@ description = "shrpid is a power monitor and watchdog daemon for the SH-RPi."
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "aiohttp>=3.10.11",
-    "dateparser>=1.2.0",
-    "loguru>=0.7.3",
-    "pyyaml>=6.0.2",
-    "rich>=13.9.4",
-    "smbus2>=0.5.0",
-    "typer>=0.15.1",
+  "aiohttp>=3.10.11",
+  "dateparser>=1.2.0",
+  "loguru>=0.7.3",
+  "pyyaml>=6.0.2",
+  "smbus2>=0.5.0",
+  "typer-slim>=0.16.0",
 ]
 authors = [{ name = "Matti Airas", email = "matti.airas@hatlabs.fi" }]
 
@@ -28,18 +27,18 @@ shrpid = "shrpi.__main__:daemon"
 
 [dependency-groups]
 dev = [
-    "coverage>=7.6.1",
-    "coverage-badge>=1.1.2",
-    "mypy>=1.14.1",
-    "mypy-extensions>=1.0.0",
-    "pydocstyle>=6.3.0",
-    "pylint>=3.2.7",
-    "pytest>=8.3.4",
-    "pytest-cov>=5.0.0",
-    "pyupgrade>=3.8.0",
-    "ruff>=0.9.0",
-    "types-dateparser>=1.2.0.20240420",
-    "types-pyyaml>=6.0.12.20241230",
+  "coverage>=7.6.1",
+  "coverage-badge>=1.1.2",
+  "mypy>=1.14.1",
+  "mypy-extensions>=1.0.0",
+  "pydocstyle>=6.3.0",
+  "pylint>=3.2.7",
+  "pytest>=8.3.4",
+  "pytest-cov>=5.0.0",
+  "pyupgrade>=3.8.0",
+  "ruff>=0.9.0",
+  "types-dateparser>=1.2.0.20240420",
+  "types-pyyaml>=6.0.12.20241230",
 ]
 
 [tool.ruff]
@@ -77,8 +76,22 @@ warn_unused_ignores = true
 [tool.pytest.ini_options]
 # https://docs.pytest.org/en/6.2.x/customize.html#pyproject-toml
 # Directories that are not visited by pytest collector:
-doctest_optionflags = ["NUMBER", "NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
-norecursedirs = ["hooks", "*.egg", ".eggs", "dist", "build", "docs", ".tox", ".git", "__pycache__"]
+doctest_optionflags = [
+  "NUMBER",
+  "NORMALIZE_WHITESPACE",
+  "IGNORE_EXCEPTION_DETAIL",
+]
+norecursedirs = [
+  "hooks",
+  "*.egg",
+  ".eggs",
+  "dist",
+  "build",
+  "docs",
+  ".tox",
+  ".git",
+  "__pycache__",
+]
 
 # Extra options:
 addopts = [

--- a/src/shrpi/cli.py
+++ b/src/shrpi/cli.py
@@ -1,11 +1,10 @@
 import asyncio
 import pathlib
+from enum import Enum
 from typing import Any, Dict
 
-import aiohttp
 import typer
-from rich.console import Console
-from rich.table import Table
+from aiohttp import ClientSession, UnixConnector
 
 """SH-RPi command line interface communicates with the shrpid daemon and
 allows the user to observe and control the device."""
@@ -15,27 +14,43 @@ app = typer.Typer(
     help=__doc__,
     add_completion=False,
 )
-console = Console()
 
 # dictionary of state variables
 state: Dict[str, Any] = {}
 
 
-async def get_json(session: aiohttp.ClientSession, url: str) -> Any:
+class Ansi(Enum):
+    BLACK = 0
+    RED = 1
+    GREEN = 2
+    YELLOW = 3
+    BLUE = 4
+    MAGENTA = 5
+    CYAN = 6
+    WHITE = 7
+    DEFAULT = 9
+
+    def __str__(self) -> str:
+        return f"\x1b[3{self.value}m"
+
+
+def print_colored(*text: str, color: Ansi = Ansi.WHITE):
+    print(color, *text, "\x1b[0m")
+
+
+async def get_json(session: ClientSession, url: str) -> Any:
     """Get JSON data from the given URL."""
     async with session.get(url) as resp:
         return await resp.json()
 
 
-async def post_json(
-    session: aiohttp.ClientSession, url: str, data: Dict[Any, Any]
-) -> int:
+async def post_json(session: ClientSession, url: str, data: Dict[Any, Any]) -> int:
     """Post JSON data to the given URL."""
     async with session.post(url, json=data) as resp:
         return resp.status
 
 
-async def put_json(session: aiohttp.ClientSession, url: str, data: Any) -> int:
+async def put_json(session: ClientSession, url: str, data: Any) -> int:
     """Put JSON data to the given URL."""
     async with session.put(url, json=data) as resp:
         return resp.status
@@ -43,8 +58,8 @@ async def put_json(session: aiohttp.ClientSession, url: str, data: Any) -> int:
 
 async def async_print_all(socket_path: pathlib.Path) -> None:
     """Print all data from the device."""
-    connector = aiohttp.UnixConnector(path=str(socket_path))
-    async with aiohttp.ClientSession(connector=connector) as session:
+    connector = UnixConnector(path=str(socket_path))
+    async with ClientSession(connector=connector) as session:
         coro1 = get_json(session, "http://localhost:8080/version")
         coro2 = get_json(session, "http://localhost:8080/state")
         coro3 = get_json(session, "http://localhost:8080/config")
@@ -55,40 +70,38 @@ async def async_print_all(socket_path: pathlib.Path) -> None:
 
         # Print all gathered data in a neat table
 
-        table = Table(show_header=False, box=None)
-        table.add_column("Key", style="bold")
-        table.add_column("Value", justify="right")
-        table.add_column("Unit")
+        table = []
 
-        table.add_row("Hardware version", str(version["hardware_version"]), "")
-        table.add_row("Firmware version", str(version["firmware_version"]), "")
-        table.add_row("Daemon version", str(version["daemon_version"]), "")
-        table.add_section()
+        table.append(("Hardware version", str(version["hardware_version"]), ""))
+        table.append(("Firmware version", str(version["firmware_version"]), ""))
+        table.append(("Daemon version", str(version["daemon_version"]), ""))
 
-        table.add_row("State", str(state["state"]), "")
-        table.add_row("5V output", str(state["5v_output_enabled"]), "")
-        table.add_row("Watchdog enabled", str(state["watchdog_enabled"]), "")
-        table.add_section()
+        table.append(("State", str(state["state"]), ""))
+        table.append(("5V output", str(state["5v_output_enabled"]), ""))
+        table.append(("Watchdog enabled", str(state["watchdog_enabled"]), ""))
 
-        table.add_row("Watchdog timeout", f"{config['watchdog_timeout']:.1f}", "s")
-        table.add_row("Power-on threshold", f"{config['power_on_threshold']:.1f}", "V")
-        table.add_row(
-            "Power-off threshold", f"{config['power_off_threshold']:.1f}", "V"
+        table.append(("Watchdog timeout", f"{config['watchdog_timeout']:.1f}", "s"))
+        table.append(("Power-on threshold", f"{config['power_on_threshold']:.1f}", "V"))
+        table.append(
+            ("Power-off threshold", f"{config['power_off_threshold']:.1f}", "V")
         )
         if config["led_brightness"] is not None:
-            table.add_row(
-                "LED brightness", f"{100 * config['led_brightness'] / 255:.1f}", "%"
+            table.append(
+                ("LED brightness", f"{100 * config['led_brightness'] / 255:.1f}", "%")
             )
-        table.add_section()
 
-        table.add_row("Voltage in", f"{values['V_in']:.1f}", "V")
+        table.append(("Voltage in", f"{values['V_in']:.1f}", "V"))
         if values["I_in"] is not None:
-            table.add_row("Current in", f"{values['I_in']:.2f}", "A")
-        table.add_row("Supercap voltage", f"{values['V_supercap']:.2f}", "V")
+            table.append(("Current in", f"{values['I_in']:.2f}", "A"))
+        table.append(("Supercap voltage", f"{values['V_supercap']:.2f}", "V"))
         if values["T_mcu"] is not None:
-            table.add_row("MCU temperature", f"{values['T_mcu'] - 273.15:.1f}", "°C")
+            table.append(("MCU temperature", f"{values['T_mcu'] - 273.15:.1f}", "°C"))
 
-        console.print(table)
+        keys, values, _ = zip(*table)
+        klen = max(*keys, key=len)
+        vlen = max(*values, key=len)
+        for key, val, unit in table:
+            print(f"{key:<{klen}}  {val:>{vlen}}  {unit}")
 
 
 @app.command("print")
@@ -99,11 +112,11 @@ def print_all() -> None:
 
 async def async_shutdown(socket_path: pathlib.Path) -> None:
     """Tell the device to wait for shutdown."""
-    connector = aiohttp.UnixConnector(path=str(socket_path))
-    async with aiohttp.ClientSession(connector=connector) as session:
+    connector = UnixConnector(path=str(socket_path))
+    async with ClientSession(connector=connector) as session:
         response = await post_json(session, "http://localhost:8080/shutdown", {})
         if response != 204:
-            console.print(f"Error: Received HTTP status {response}", style="red")
+            print_colored(f"Error: Received HTTP status {response}", color=Ansi.RED)
 
 
 @app.command("shutdown")
@@ -115,11 +128,11 @@ def shutdown() -> None:
 async def async_sleep(socket_path: pathlib.Path, time: Dict[str, str]) -> None:
     """Tell the device to sleep."""
 
-    connector = aiohttp.UnixConnector(path=str(socket_path))
-    async with aiohttp.ClientSession(connector=connector) as session:
+    connector = UnixConnector(path=str(socket_path))
+    async with ClientSession(connector=connector) as session:
         response = await post_json(session, "http://localhost:8080/sleep", time)
         if response != 204:
-            console.print(f"Error: Received HTTP status {response}", style="red")
+            print_colored(f"Error: Received HTTP status {response}", color=Ansi.RED)
 
 
 @app.command("sleep")
@@ -148,13 +161,13 @@ set_app = typer.Typer(help="Set configuration values.")
 
 async def async_set_watchdog(socket_path: pathlib.Path, timeout: float) -> None:
     """Set watchdog timeout in seconds. Value 0 disables the watchdog."""
-    connector = aiohttp.UnixConnector(path=str(socket_path))
-    async with aiohttp.ClientSession(connector=connector) as session:
+    connector = UnixConnector(path=str(socket_path))
+    async with ClientSession(connector=connector) as session:
         response = await put_json(
             session, "http://localhost:8080/config/watchdog_timeout", timeout
         )
         if response != 204:
-            console.print(f"Error: Received HTTP status {response}", style="red")
+            print_colored(f"Error: Received HTTP status {response}", color=Ansi.RED)
 
 
 @set_app.command("watchdog")
@@ -169,13 +182,13 @@ async def async_set_power_on_threshold(
     socket_path: pathlib.Path, threshold: float
 ) -> None:
     """Set power-on threshold in volts."""
-    connector = aiohttp.UnixConnector(path=str(socket_path))
-    async with aiohttp.ClientSession(connector=connector) as session:
+    connector = UnixConnector(path=str(socket_path))
+    async with ClientSession(connector=connector) as session:
         response = await put_json(
             session, "http://localhost:8080/config/power_on_threshold", threshold
         )
         if response != 204:
-            console.print(f"Error: Received HTTP status {response}", style="red")
+            print_colored(f"Error: Received HTTP status {response}", color=Ansi.RED)
 
 
 @set_app.command("power-on-threshold")
@@ -190,13 +203,13 @@ async def async_set_power_off_threshold(
     socket_path: pathlib.Path, threshold: float
 ) -> None:
     """Set power-off threshold in volts."""
-    connector = aiohttp.UnixConnector(path=str(socket_path))
-    async with aiohttp.ClientSession(connector=connector) as session:
+    connector = UnixConnector(path=str(socket_path))
+    async with ClientSession(connector=connector) as session:
         response = await put_json(
             session, "http://localhost:8080/config/power_off_threshold", threshold
         )
         if response != 204:
-            console.print(f"Error: Received HTTP status {response}", style="red")
+            print_colored(f"Error: Received HTTP status {response}", color=Ansi.RED)
 
 
 @set_app.command("power-off-threshold")
@@ -212,13 +225,13 @@ async def async_set_led_brightness(
 ) -> None:
     """Set LED brightness in percent."""
     brightness_byte = int(brightness * 255 / 100)
-    connector = aiohttp.UnixConnector(path=str(socket_path))
-    async with aiohttp.ClientSession(connector=connector) as session:
+    connector = UnixConnector(path=str(socket_path))
+    async with ClientSession(connector=connector) as session:
         response = await put_json(
             session, "http://localhost:8080/config/led_brightness", brightness_byte
         )
         if response != 204:
-            console.print(f"Error: Received HTTP status {response}", style="red")
+            print_colored(f"Error: Received HTTP status {response}", color=Ansi.RED)
 
 
 @set_app.command("led")

--- a/src/shrpi/daemon.py
+++ b/src/shrpi/daemon.py
@@ -19,7 +19,6 @@ from shrpi.const import (
     VERSION,
 )
 from shrpi.i2c import DeviceNotFoundError, SHRPiDevice
-from shrpi.server import run_http_server
 from shrpi.state_machine import run_state_machine
 
 
@@ -190,6 +189,8 @@ async def async_main():
         poweroff=args.poweroff,
         dry_run=args.n,
     )
+    from shrpi.server import run_http_server
+
     coro2 = run_http_server(
         shrpi_device, socket_path, socket_group, poweroff=args.poweroff
     )

--- a/src/shrpi/server.py
+++ b/src/shrpi/server.py
@@ -7,7 +7,6 @@ import numbers
 import os
 import pathlib
 
-import dateparser
 from aiohttp import web
 from loguru import logger
 
@@ -75,6 +74,8 @@ class RouteHandlers:
 
         data = await request.json()
         if "datetime" in data:
+            import dateparser
+
             dt = dateparser.parse(data["datetime"])
             if dt is None:
                 return web.Response(status=400, text="Invalid datetime format")


### PR DESCRIPTION
## Description

This switches the install script to use uv instead of pipx. I originally did this because i noticed a about 4 second delay between running `shrpi --help` and getting the help output, and i though it might be pipx doing that.

You might want to carefully consider whether you want to accept this in its current state: it installs `uv` into `/usr/local/bin/uv` even if the user already has a user-specific `uv` installed. This is partly because uv doesn't have a apt package [(yet)](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1069776)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
