### PR TITLE
Install with uv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ if [ -f /usr/local/bin/shrpi ]; then
 fi
 
 # install the daemon itself
-UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
+UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
 
 # copy the service definition file in place
 install -o root shrpid.service /lib/systemd/system

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,9 @@ pushd configs
 popd
 
 # install uv, which manages venv for installing the daemon
-curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+if ! [[ $(type -P "$cmd") ]]; then
+    curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+fi
 
 # If a legacy venv is present, remove it
 if [ -d /usr/local/lib/shrpid ]; then
@@ -37,11 +39,9 @@ if [ -f /usr/local/bin/shrpi ]; then
 fi
 
 # install the daemon itself
-
 UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
 
 # copy the service definition file in place
-
 install -o root shrpid.service /lib/systemd/system
 systemctl daemon-reload
 systemctl enable shrpid

--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,8 @@ pushd configs
 ./install_configs.sh "$@"
 popd
 
-# install the daemon build dependencies
-
-apt install -y python3-pip python3-venv pipx
+# install uv, which manages venv for installing the daemon
+curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 
 # If a legacy venv is present, remove it
 if [ -d /usr/local/lib/shrpid ]; then
@@ -37,13 +36,9 @@ if [ -f /usr/local/bin/shrpi ]; then
     rm /usr/local/bin/shrpi
 fi
 
-# Create a venv for the daemon
-python3 -m venv /usr/local/lib/shrpid
-source /usr/local/lib/shrpid/bin/activate
-
 # install the daemon itself
 
-PIPX_BIN_DIR=/usr/local/bin PIPX_HOME=/opt/pipx pipx install --force .
+UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/opt/uv uv tool install --force .
 
 # copy the service definition file in place
 

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ pushd configs
 popd
 
 # install uv, which manages venv for installing the daemon
-if ! [[ $(type -P "$cmd") ]]; then
+if ! [[ $(type -P uv) ]]; then
     curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 fi
 


### PR DESCRIPTION
## Description

This switches the install script to use uv instead of pipx. I originally did this because i noticed a about 4 second delay between running `shrpi --help` and getting the help output, and i though it might be pipx doing that. It might not have been pipx, and instead bytecode compilation, but i've only tested that after swapping it over to use uv.

Before this PR:
`import time:      2927 |    6728524 | shrpi.__main__`
After this PR:
`import time:      1509 |    2878676 | shrpi.__main__`

You might want to carefully consider whether you want to accept this in its current state: it installs `uv` into `/usr/local/bin/uv` even if the user already has a user-specific `uv` installed. This is partly because uv doesn't have a apt package [(yet)](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1069776)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
